### PR TITLE
fix: Script lang issue with SFC compiler

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,4 +2,7 @@ module.exports = {
   root: true,
   extends: ["@nuxt/eslint-config", "prettier"],
   plugins: ["prettier"],
+  rules: {
+    "vue/require-default-prop": "off"
+  }
 };

--- a/docs/pages/tooltip.vue
+++ b/docs/pages/tooltip.vue
@@ -23,6 +23,7 @@ const scrollableRef = ref<HTMLElement | null>(null);
 
       <div class="mt-1 flex gap-5">
         <UiTooltip
+          side="top"
           align="end"
           content="Hello! I'm a tooltip with alignment set to 'end' which makes me align to the right"
         >

--- a/src/runtime/components/elements/Badge.vue
+++ b/src/runtime/components/elements/Badge.vue
@@ -1,35 +1,25 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
+import { useUI } from '#ui/composables/useUI';
+import type { BadgeColor, BadgeSize, Strategy } from '#ui/types';
 import { badge } from '#ui/ui.config';
 import { mergeConfig } from '#ui/utils';
+import { twJoin, twMerge } from 'tailwind-merge';
+import { computed, defineOptions, toRef, type PropType } from 'vue';
 
 const config = mergeConfig<typeof badge>(appConfig.ui?.badge?.strategy, appConfig.ui?.badge, badge);
 type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
-import { useUI } from '#ui/composables/useUI';
-import type { BadgeColor, BadgeSize, Strategy } from '#ui/types';
-import { twJoin, twMerge } from 'tailwind-merge';
-import type { PropType } from 'vue';
-import { defineOptions, toRef } from 'vue';
 
 defineOptions({ inheritAttrs: false });
 
 const props = defineProps({
   dot: Boolean,
   interactive: Boolean,
+  size: String as PropType<BadgeSize>,
+  color: String as PropType<BadgeColor>,
   label: { type: [String, Number], default: null },
-  size: {
-    type: String as PropType<BadgeSize>,
-    default: () => config.default.size,
-  },
-  color: {
-    type: String as PropType<BadgeColor>,
-    default: () => config.default.color,
-  },
   class: {
     type: [String, Object, Array] as PropType<any>,
     default: undefined,
@@ -41,13 +31,17 @@ const props = defineProps({
 });
 
 const { ui, attrs } = useUI('badge', toRef(props, 'ui'), config);
+
+// With config defaults
+const size = computed(() => props.size ?? ui.value.default.size);
+const color = computed(() => props.color ?? ui.value.default.size);
 </script>
 
 <template>
   <span
     v-bind="attrs"
     :data-interactive="interactive ? '' : undefined"
-    :class="twMerge(twJoin(ui.base, ui.font, ui.size[props.size], ui.color[props.color]), props.class)"
+    :class="twMerge(twJoin(ui.base, ui.font, ui.size[size], ui.color[color]), props.class)"
   >
     <svg v-if="dot" viewBox="0 0 6 6" aria-hidden="true" fill="currentColor" class="size-1.5">
       <circle cx="3" cy="3" r="3" />

--- a/src/runtime/components/elements/Button.vue
+++ b/src/runtime/components/elements/Button.vue
@@ -1,22 +1,19 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
-import { button } from '#ui/ui.config';
-import { mergeConfig } from '#ui/utils';
-
-const config = mergeConfig<typeof button>(appConfig.ui?.button?.strategy, appConfig.ui?.button, button);
-type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
 import UiLink from '#ui/components/elements/Link.vue';
 import { useUI } from '#ui/composables/useUI';
-import type { ButtonProps, ButtonSize, ButtonVariant, Strategy } from '#ui/types';
+import type { ButtonProps, Strategy } from '#ui/types';
+import { button } from '#ui/ui.config';
+import { mergeConfig } from '#ui/utils';
 import { getUiLinkProps } from '#ui/utils/links';
 import { Primitive, useForwardProps } from 'radix-vue';
 import { twJoin, twMerge } from 'tailwind-merge';
 import { computed, defineOptions, toRef, withDefaults } from 'vue';
+
+const config = mergeConfig<typeof button>(appConfig.ui?.button?.strategy, appConfig.ui?.button, button);
+type UiConfig = Partial<typeof config> & { strategy?: Strategy };
 
 defineOptions({ inheritAttrs: false });
 
@@ -24,18 +21,16 @@ const props = withDefaults(defineProps<ButtonProps<UiConfig>>(), {
   as: 'button',
   type: 'button',
   padded: true,
-  class: undefined,
-  label: undefined,
-  leftIcon: undefined,
-  rightIcon: undefined,
   to: () => undefined as ButtonProps['to'],
-  size: () => config.default.size as ButtonSize,
-  variant: () => config.default.variant as ButtonVariant,
-  loadingIcon: () => config.default.loadingIcon,
   ui: () => ({}) as UiConfig,
 });
 
 const { ui, attrs } = useUI('button', toRef(props, 'ui'), config);
+
+// With config defaults
+const size = computed(() => props.size ?? ui.value.default.size);
+const variant = computed(() => props.variant ?? ui.value.default.variant);
+const loadingIcon = computed(() => props.loadingIcon ?? ui.value.default.loadingIcon);
 
 const baseClasses = computed(() =>
   twMerge(
@@ -44,23 +39,23 @@ const baseClasses = computed(() =>
       ui.value.font,
       ui.value.rounded,
       ui.value.transition,
-      ui.value.size[props.size],
-      ui.value.gap[props.size],
-      props.padded && ui.value.padding[props.size],
-      ui.value.variant[props.variant],
+      ui.value.size[size.value],
+      ui.value.gap[size.value],
+      props.padded && ui.value.padding[size.value],
+      ui.value.variant[variant.value],
       props.block ? 'w-full flex justify-center items-center' : 'inline-flex items-center',
     ),
     props.class,
   ),
 );
 
-const leftIconClasses = computed(() => twJoin(ui.value.icon.base, ui.value.icon.size[props.size]));
+const leftIconClasses = computed(() => twJoin(ui.value.icon.base, ui.value.icon.size[size.value]));
 const rightIconClasses = computed(() =>
-  twJoin(ui.value.icon.base, ui.value.icon.size[props.size], props.loading && 'animate-spin'),
+  twJoin(ui.value.icon.base, ui.value.icon.size[size.value], props.loading && 'animate-spin'),
 );
 
 const rightIconName = computed(() => {
-  if (props.loading) return props.loadingIcon;
+  if (props.loading) return loadingIcon.value;
   return props.rightIcon;
 });
 

--- a/src/runtime/components/forms/Combobox.vue
+++ b/src/runtime/components/forms/Combobox.vue
@@ -1,23 +1,13 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
-import { combobox } from '#ui/ui.config';
-import { mergeConfig } from '#ui/utils';
-
-const config = mergeConfig<typeof combobox>(
-  appConfig.ui?.combobox?.strategy,
-  appConfig.ui?.combobox,
-  combobox,
-);
-type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
 import UiIcon from '#ui/components/elements/Icon.vue';
 import UiFormField from '#ui/components/forms/FormField.vue';
 import { useUI } from '#ui/composables/useUI';
 import type { ComboboxItem, ComboboxOptions, ComboboxProps, Strategy } from '#ui/types';
+import { combobox } from '#ui/ui.config';
+import { mergeConfig } from '#ui/utils';
 import { getUiFormFieldProps } from '#ui/utils/forms';
 import { useDebounceFn, useToNumber } from '@vueuse/core';
 import omit from 'just-omit';
@@ -27,26 +17,32 @@ import { Combobox } from 'radix-vue/namespaced';
 import { twJoin, twMerge } from 'tailwind-merge';
 import { computed, defineOptions, ref, toRef, watch, withDefaults } from 'vue';
 
+const config = mergeConfig<typeof combobox>(
+  appConfig.ui?.combobox?.strategy,
+  appConfig.ui?.combobox,
+  combobox,
+);
+type UiConfig = Partial<typeof config> & { strategy?: Strategy };
+
 defineOptions({ inheritAttrs: false });
 const props = withDefaults(defineProps<ComboboxProps<UiConfig>>(), {
-  suffixIcon: () => config.default.suffixIcon,
-  searchIcon: () => config.default.searchIcon,
-  loadingIcon: () => config.default.loadingIcon,
-  indicatorIcon: () => config.default.indicatorIcon,
-
   class: undefined,
   ui: () => ({}) as UiConfig,
-  offset: () => config.default.offset,
-  side: () => config.default.side,
-  align: () => config.default.align,
-
   modelValue: undefined,
   emptyMsg: 'No results',
 });
 const emits = defineEmits<ComboboxRootEmits>();
 
 const { ui } = useUI('combobox', toRef(props, 'ui'), config);
-const numOffset = useToNumber(props.offset);
+
+// With config defaults
+const numOffset = useToNumber(() => props.offset ?? ui.value.default.offset);
+const suffixIcon = computed(() => props.suffixIcon ?? ui.value.default.suffixIcon);
+const searchIcon = computed(() => props.searchIcon ?? ui.value.default.searchIcon);
+const loadingIcon = computed(() => props.loadingIcon ?? ui.value.default.loadingIcon);
+const indicatorIcon = computed(() => props.indicatorIcon ?? ui.value.default.indicatorIcon);
+const side = computed(() => props.side ?? ui.value.default.side);
+const align = computed(() => props.align ?? ui.value.default.align);
 
 const rootProps = computed(() => pick(props, ['defaultValue', 'disabled', 'multiple', 'name', 'modelValue']));
 const forwarded = useForwardPropsEmits(rootProps, emits);
@@ -199,7 +195,7 @@ watch(
             {{ displayValue }}
           </span>
 
-          <UiIcon :name="props.suffixIcon" :class="[ui.anchor.icon, 'mr-3']" />
+          <UiIcon :name="suffixIcon" :class="[ui.anchor.icon, 'mr-3']" />
         </Combobox.Trigger>
       </Combobox.Anchor>
     </UiFormField>
@@ -207,13 +203,13 @@ watch(
     <Combobox.Portal>
       <Combobox.Content
         position="popper"
-        :side="props.side"
-        :align="props.align"
+        :side="side"
+        :align="align"
         :side-offset="numOffset"
         :class="[ui.content.base, ui.content.border, ui.content.size, ui.content.transition]"
       >
         <div :class="ui.input.container">
-          <UiIcon :name="props.searchIcon" :class="[ui.input.icon, 'ml-3']" />
+          <UiIcon :name="searchIcon" :class="[ui.input.icon, 'ml-3']" />
 
           <Combobox.Input
             :id="props.name"
@@ -232,7 +228,7 @@ watch(
           </Combobox.Empty>
 
           <div v-if="_loading" :class="ui.loading.base">
-            <UiIcon :name="props.loadingIcon" :class="ui.loading.icon" />
+            <UiIcon :name="loadingIcon" :class="ui.loading.icon" />
           </div>
 
           <template v-else-if="Array.isArray(_options)">
@@ -244,7 +240,7 @@ watch(
               :class="itemClasses"
             >
               <Combobox.ItemIndicator as-child>
-                <UiIcon :name="props.indicatorIcon" :class="ui.item.indicator" />
+                <UiIcon :name="indicatorIcon" :class="ui.item.indicator" />
               </Combobox.ItemIndicator>
 
               <span :class="ui.item.label">{{ option.label }}</span>
@@ -263,7 +259,7 @@ watch(
                 :class="itemClasses"
               >
                 <Combobox.ItemIndicator as-child>
-                  <UiIcon :name="props.indicatorIcon" :class="ui.item.indicator" />
+                  <UiIcon :name="indicatorIcon" :class="ui.item.indicator" />
                 </Combobox.ItemIndicator>
 
                 <span :class="ui.item.label">{{ option.label }}</span>

--- a/src/runtime/components/forms/FormField.vue
+++ b/src/runtime/components/forms/FormField.vue
@@ -1,9 +1,15 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
+import UiInputLabel from '#ui/components/forms/FormLabel.vue';
+import { useUI } from '#ui/composables/useUI';
+import type { FormFieldProps, Strategy } from '#ui/types';
 import { formField } from '#ui/ui.config';
 import { mergeConfig } from '#ui/utils';
+import { Primitive } from 'radix-vue';
+import { twMerge } from 'tailwind-merge';
+import { computed, toRef, withDefaults } from 'vue';
 
 const config = mergeConfig<typeof formField>(
   appConfig.ui?.formField?.strategy,
@@ -11,15 +17,6 @@ const config = mergeConfig<typeof formField>(
   formField,
 );
 type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
-import UiInputLabel from '#ui/components/forms/FormLabel.vue';
-import { useUI } from '#ui/composables/useUI';
-import type { FormFieldProps, Strategy } from '#ui/types';
-import { Primitive } from 'radix-vue';
-import { twMerge } from 'tailwind-merge';
-import { computed, toRef, withDefaults } from 'vue';
 
 const props = withDefaults(defineProps<FormFieldProps<UiConfig>>(), {
   as: 'div',

--- a/src/runtime/components/forms/FormInput.vue
+++ b/src/runtime/components/forms/FormInput.vue
@@ -1,9 +1,19 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
+import UiIcon from '#ui/components/elements/Icon.vue';
+import UiFormField from '#ui/components/forms/FormField.vue';
+import { useUI } from '#ui/composables/useUI';
+import type { InputProps, Strategy } from '#ui/types';
 import { formInput } from '#ui/ui.config';
 import { mergeConfig } from '#ui/utils';
+import { getUiFormFieldProps } from '#ui/utils/forms';
+import { useVModel } from '@vueuse/core';
+import omit from 'just-omit';
+import { useForwardProps } from 'radix-vue';
+import { twMerge } from 'tailwind-merge';
+import { defineOptions, toRef, withDefaults } from 'vue';
 
 const config = mergeConfig<typeof formInput>(
   appConfig.ui?.formInput?.strategy,
@@ -11,19 +21,6 @@ const config = mergeConfig<typeof formInput>(
   formInput,
 );
 type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
-import UiIcon from '#ui/components/elements/Icon.vue';
-import UiFormField from '#ui/components/forms/FormField.vue';
-import { useUI } from '#ui/composables/useUI';
-import type { InputProps, Strategy } from '#ui/types';
-import { getUiFormFieldProps } from '#ui/utils/forms';
-import { useVModel } from '@vueuse/core';
-import omit from 'just-omit';
-import { useForwardProps } from 'radix-vue';
-import { twMerge } from 'tailwind-merge';
-import { defineOptions, toRef, withDefaults } from 'vue';
 
 defineOptions({ inheritAttrs: false });
 const props = withDefaults(defineProps<InputProps<UiConfig>>(), {
@@ -36,11 +33,11 @@ const props = withDefaults(defineProps<InputProps<UiConfig>>(), {
   defaultValue: undefined,
   ui: () => ({}) as UiConfig,
 });
-const emits = defineEmits({
-  'update:modelValue': (payload: string | number) => true,
-  'click:prefix': () => true,
-  'click:suffix': () => true,
-});
+const emits = defineEmits<{
+  (e: 'update:modelValue', payload: string | number): void;
+  (e: 'click:prefix'): void;
+  (e: 'click:suffix'): void;
+}>();
 
 const $value = useVModel(props, 'modelValue', emits, { passive: true, defaultValue: props.defaultValue });
 

--- a/src/runtime/components/forms/FormLabel.vue
+++ b/src/runtime/components/forms/FormLabel.vue
@@ -1,9 +1,13 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
+import { useUI } from '#ui/composables/useUI';
+import type { Strategy } from '#ui/types';
 import { formLabel } from '#ui/ui.config';
 import { mergeConfig } from '#ui/utils';
+import { Label, type LabelProps } from 'radix-vue';
+import { toRef, withDefaults } from 'vue';
 
 const config = mergeConfig<typeof formLabel>(
   appConfig.ui?.formLabel?.strategy,
@@ -11,13 +15,6 @@ const config = mergeConfig<typeof formLabel>(
   formLabel,
 );
 type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
-import { useUI } from '#ui/composables/useUI';
-import type { Strategy } from '#ui/types';
-import { Label, type LabelProps } from 'radix-vue';
-import { toRef, withDefaults } from 'vue';
 
 const props = withDefaults(
   defineProps<LabelProps & { mandatory?: boolean; error?: boolean; class?: any; ui?: UiConfig }>(),

--- a/src/runtime/components/forms/RadioGroupItem.vue
+++ b/src/runtime/components/forms/RadioGroupItem.vue
@@ -1,9 +1,15 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
+import { useUI } from '#ui/composables/useUI';
+import type { Strategy } from '#ui/types';
 import { formRadioGroupItem } from '#ui/ui.config';
 import { mergeConfig } from '#ui/utils';
+import omit from 'just-omit';
+import { RadioGroupIndicator, RadioGroupItem, useForwardProps, type RadioGroupItemProps } from 'radix-vue';
+import { twJoin, twMerge } from 'tailwind-merge';
+import { computed, toRef, withDefaults } from 'vue';
 
 const config = mergeConfig<typeof formRadioGroupItem>(
   appConfig.ui?.formRadioGroupItem?.strategy,
@@ -11,20 +17,9 @@ const config = mergeConfig<typeof formRadioGroupItem>(
   formRadioGroupItem,
 );
 type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
+type Props = RadioGroupItemProps & { class?: any; ui?: UiConfig };
 
-<script setup lang="ts">
-import { useUI } from '#ui/composables/useUI';
-import type { Strategy } from '#ui/types';
-import omit from 'just-omit';
-import { RadioGroupIndicator, RadioGroupItem, type RadioGroupItemProps, useForwardProps } from 'radix-vue';
-import { twJoin, twMerge } from 'tailwind-merge';
-import { computed, toRef, withDefaults } from 'vue';
-
-const props = withDefaults(defineProps<RadioGroupItemProps & { class?: any; ui?: UiConfig }>(), {
-  class: undefined,
-  ui: () => ({}) as UiConfig,
-});
+const props = withDefaults(defineProps<Props>(), { class: undefined, ui: () => ({}) as UiConfig });
 
 const { ui } = useUI('formRadioGroupItem', toRef(props, 'ui'), config);
 

--- a/src/runtime/components/forms/Switch.vue
+++ b/src/runtime/components/forms/Switch.vue
@@ -1,21 +1,11 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
-import { formSwitch } from '#ui/ui.config';
-import { mergeConfig } from '#ui/utils';
-
-const config = mergeConfig<typeof formSwitch>(
-  appConfig.ui?.formSwitch?.strategy,
-  appConfig.ui?.formSwitch,
-  formSwitch,
-);
-type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
 import { useUI } from '#ui/composables/useUI';
 import type { Strategy } from '#ui/types';
+import { formSwitch } from '#ui/ui.config';
+import { mergeConfig } from '#ui/utils';
 import omit from 'just-omit';
 import {
   SwitchRoot,
@@ -26,6 +16,13 @@ import {
 } from 'radix-vue';
 import { twJoin, twMerge } from 'tailwind-merge';
 import { computed, toRef, withDefaults } from 'vue';
+
+const config = mergeConfig<typeof formSwitch>(
+  appConfig.ui?.formSwitch?.strategy,
+  appConfig.ui?.formSwitch,
+  formSwitch,
+);
+type UiConfig = Partial<typeof config> & { strategy?: Strategy };
 
 const props = withDefaults(defineProps<SwitchRootProps & { class?: any; ui?: UiConfig }>(), {
   class: undefined,

--- a/src/runtime/components/layout/Container.vue
+++ b/src/runtime/components/layout/Container.vue
@@ -1,9 +1,13 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
-
+import { useUI } from '#ui/composables/useUI';
+import type { Strategy } from '#ui/types';
 import { container } from '#ui/ui.config';
 import { mergeConfig } from '#ui/utils';
+import { twJoin, twMerge } from 'tailwind-merge';
+import type { PropType } from 'vue';
+import { defineOptions, toRef } from 'vue';
 
 const config = mergeConfig<typeof container>(
   appConfig.ui.container.strategy,
@@ -11,14 +15,6 @@ const config = mergeConfig<typeof container>(
   container,
 );
 type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
-import { useUI } from '#ui/composables/useUI';
-import type { Strategy } from '#ui/types';
-import { twJoin, twMerge } from 'tailwind-merge';
-import type { PropType } from 'vue';
-import { defineOptions, toRef } from 'vue';
 
 defineOptions({ inheritAttrs: false });
 

--- a/src/runtime/components/overlays/Dialog.vue
+++ b/src/runtime/components/overlays/Dialog.vue
@@ -1,22 +1,19 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
-import { dialog } from '#ui/ui.config';
-import { mergeConfig } from '#ui/utils';
-
-const config = mergeConfig<typeof dialog>(appConfig.ui?.dialog?.strategy, appConfig.ui?.dialog, dialog);
-type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
 import { useUI } from '#ui/composables/useUI';
 import type { Strategy } from '#ui/types';
+import { dialog } from '#ui/ui.config';
+import { mergeConfig } from '#ui/utils';
 import { useVModel } from '@vueuse/core';
 import { Dialog } from 'radix-vue/namespaced';
 import { twMerge } from 'tailwind-merge';
 import type { PropType } from 'vue';
 import { defineOptions, toRef } from 'vue';
+
+const config = mergeConfig<typeof dialog>(appConfig.ui?.dialog?.strategy, appConfig.ui?.dialog, dialog);
+type UiConfig = Partial<typeof config> & { strategy?: Strategy };
 
 defineOptions({ inheritAttrs: false });
 
@@ -28,7 +25,7 @@ const props = defineProps({
     default: () => ({}) as UiConfig,
   },
 });
-const emits = defineEmits({ 'update:open': (value: boolean) => true });
+const emits = defineEmits<{ (e: 'update:open', value: boolean): void }>();
 
 const $open = useVModel(props, 'open', emits, {
   defaultValue: props.defaultOpen,

--- a/src/runtime/components/overlays/Slideover.vue
+++ b/src/runtime/components/overlays/Slideover.vue
@@ -1,9 +1,17 @@
-<script lang="ts">
+<script setup lang="ts">
 // @ts-expect-error
 import appConfig from '#build/app.config';
 
+import { useUI } from '#ui/composables/useUI';
+import type { Strategy } from '#ui/types';
 import { slideover } from '#ui/ui.config';
 import { mergeConfig } from '#ui/utils';
+import { useVModel } from '@vueuse/core';
+import type { PopoverContentProps } from 'radix-vue';
+import { Dialog } from 'radix-vue/namespaced';
+import { twJoin, twMerge } from 'tailwind-merge';
+import type { PropType } from 'vue';
+import { computed, defineOptions, toRef } from 'vue';
 
 const config = mergeConfig<typeof slideover>(
   appConfig.ui?.slideover?.strategy,
@@ -11,17 +19,6 @@ const config = mergeConfig<typeof slideover>(
   slideover,
 );
 type UiConfig = Partial<typeof config> & { strategy?: Strategy };
-</script>
-
-<script setup lang="ts">
-import { useUI } from '#ui/composables/useUI';
-import type { Strategy } from '#ui/types';
-import { useVModel } from '@vueuse/core';
-import type { PopoverContentProps } from 'radix-vue';
-import { Dialog } from 'radix-vue/namespaced';
-import { twJoin, twMerge } from 'tailwind-merge';
-import type { PropType } from 'vue';
-import { computed, defineOptions, toRef } from 'vue';
 
 defineOptions({ inheritAttrs: false });
 
@@ -38,7 +35,7 @@ const props = defineProps({
     default: () => ({}) as UiConfig,
   },
 });
-const emits = defineEmits({ 'update:open': (value: boolean) => true });
+const emits = defineEmits<{ (e: 'update:open', value: boolean): void }>();
 
 const $open = useVModel(props, 'open', emits, {
   defaultValue: props.defaultOpen,


### PR DESCRIPTION
This PR fixes an issue that gave the warning:

```
Pre-transform error: [@vue/compiler-sfc] <script> and <script setup> must have the same language type.
```

To solve it, we merged both `<script setup lang="ts">` and `<script lang="ts">` into the `setup` tag. This also required refactoring the components that had default settings inside of the `app.config.ts` file.