### PR TITLE
fix(Button): Type attribute not being applied

### DIFF
--- a/src/runtime/components/elements/Button.vue
+++ b/src/runtime/components/elements/Button.vue
@@ -65,6 +65,7 @@ const linkProps = useForwardProps(() => getUiLinkProps(props));
 <template>
   <Primitive
     v-bind="{ ...attrs, ...linkProps }"
+    :type="props.type"
     :as-child="asChild"
     :as="props.to ? UiLink : as"
     :class="baseClasses"


### PR DESCRIPTION
Fixed an issue where the `type` attribute for the button was not being set because it is defined as a prop but was not being bound to the Primitive.