### PR TITLE
feat(Overlays): Improve the Dialog and Slideover triggers and transitions

### DIFF
--- a/docs/pages/dialog.vue
+++ b/docs/pages/dialog.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { UiContainer, UiDialog } from '#components';
 import { DialogClose, DialogTitle } from 'radix-vue';
+import { ref } from 'vue';
+
+const show = ref(false);
 </script>
 
 <template>
@@ -8,25 +11,57 @@ import { DialogClose, DialogTitle } from 'radix-vue';
     <h1 class="demo-page-title">Dialog</h1>
     <p class="demo-page-description">Modal that pops-up to call the attention of the user.</p>
 
-    <UiDialog prevent-close>
-      <template #trigger>
-        <UiButton label="Open dialog" class="mt-4" />
-      </template>
+    <div class="demo-category-container mt-4 items-start">
+      <span class="demo-category-title"
+        >Controlled:
+        <code class="demo-code-line">"{{ show }}"</code>
+      </span>
 
-      <template #content>
-        <div class="px-6 py-8">
-          <DialogTitle class="text-xl font-medium text-gray-900">This is a dialog</DialogTitle>
-          <p class="mt-3 text-gray-600">
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Minus libero quo voluptatem perspiciatis
-            similique, omnis explicabo quos consequatur, ab adipisci itaque excepturi, voluptatum voluptatibus
-            a unde deserunt inventore veritatis quod delectus esse hic?
-          </p>
+      <UiButton label="Open dialog" class="mt-4" @click="show = true" />
 
-          <DialogClose as-child>
-            <UiButton label="Close dialog" class="mt-4" />
-          </DialogClose>
-        </div>
-      </template>
-    </UiDialog>
+      <UiDialog v-model:open="show">
+        <template #content>
+          <div class="px-6 py-8">
+            <DialogTitle class="text-xl font-medium text-gray-900">This is a controlled dialog</DialogTitle>
+            <p class="mt-3 text-gray-600">
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Minus libero quo voluptatem
+              perspiciatis similique, omnis explicabo quos consequatur, ab adipisci itaque excepturi,
+              voluptatum voluptatibus a unde deserunt inventore veritatis quod delectus esse hic?
+            </p>
+
+            <DialogClose as-child>
+              <UiButton label="Close dialog" class="mt-4" />
+            </DialogClose>
+          </div>
+        </template>
+      </UiDialog>
+    </div>
+
+    <div class="demo-category-container mt-4 items-start">
+      <span class="demo-category-title">Uncontrolled</span>
+
+      <UiDialog>
+        <template #trigger>
+          <UiButton label="Open dialog" class="mt-4" />
+        </template>
+
+        <template #content>
+          <div class="px-6 py-8">
+            <DialogTitle class="text-xl font-medium text-gray-900"
+              >This is an uncontrolled dialog</DialogTitle
+            >
+            <p class="mt-3 text-gray-600">
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Minus libero quo voluptatem
+              perspiciatis similique, omnis explicabo quos consequatur, ab adipisci itaque excepturi,
+              voluptatum voluptatibus a unde deserunt inventore veritatis quod delectus esse hic?
+            </p>
+
+            <DialogClose as-child>
+              <UiButton label="Close dialog" class="mt-4" />
+            </DialogClose>
+          </div>
+        </template>
+      </UiDialog>
+    </div>
   </UiContainer>
 </template>

--- a/docs/pages/slideover.vue
+++ b/docs/pages/slideover.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { UiButton, UiContainer, UiSlideover } from '#components';
-import { DialogClose, DialogTitle } from 'radix-vue';
+import { DialogClose, DialogDescription, DialogTitle } from 'radix-vue';
 </script>
 
 <template>
@@ -19,11 +19,11 @@ import { DialogClose, DialogTitle } from 'radix-vue';
         <div class="px-6 py-8">
           <DialogTitle class="text-xl font-medium text-gray-900">This is a slideover</DialogTitle>
 
-          <p class="mt-3 text-gray-600">
+          <DialogDescription class="mt-3 text-gray-600">
             Lorem ipsum, dolor sit amet consectetur adipisicing elit. Earum fugit impedit, natus, ea libero
             vitae soluta expedita ratione mollitia fuga similique, dicta aliquam? Distinctio nulla, vel
             quibusdam eligendi nostrum perferendis!
-          </p>
+          </DialogDescription>
 
           <DialogClose as-child>
             <UiButton label="Close dialog" class="mt-4" />

--- a/src/runtime/components/overlays/Dialog.vue
+++ b/src/runtime/components/overlays/Dialog.vue
@@ -6,11 +6,11 @@ import { useUI } from '#ui/composables/useUI';
 import type { Strategy } from '#ui/types';
 import { dialog } from '#ui/ui.config';
 import { mergeConfig } from '#ui/utils';
-import { useVModel } from '@vueuse/core';
+import { uiToTransitionProps } from '#ui/utils/transitions';
+import { usePreferredReducedMotion, useVModel } from '@vueuse/core';
 import { Dialog } from 'radix-vue/namespaced';
-import { twMerge } from 'tailwind-merge';
 import type { PropType } from 'vue';
-import { defineOptions, toRef } from 'vue';
+import { computed, defineOptions, toRef } from 'vue';
 
 const config = mergeConfig<typeof dialog>(appConfig.ui?.dialog?.strategy, appConfig.ui?.dialog, dialog);
 type UiConfig = Partial<typeof config> & { strategy?: Strategy };
@@ -25,7 +25,13 @@ const props = defineProps({
     default: () => ({}) as UiConfig,
   },
 });
-const emits = defineEmits<{ (e: 'update:open', value: boolean): void }>();
+const emits = defineEmits<{
+  (e: 'update:open', value: boolean): void;
+  (e: 'before-enter'): void;
+  (e: 'after-enter'): void;
+  (e: 'before-leave'): void;
+  (e: 'after-leave'): void;
+}>();
 
 const $open = useVModel(props, 'open', emits, {
   defaultValue: props.defaultOpen,
@@ -33,6 +39,15 @@ const $open = useVModel(props, 'open', emits, {
 });
 
 const { ui } = useUI('dialog', toRef(props, 'ui'), config);
+
+// Disable transitions when prefered reduced motion
+const reduceMotion = usePreferredReducedMotion();
+const contentTransition = computed(() =>
+  reduceMotion.value === 'no-preference' ? uiToTransitionProps(ui.value.transition) : {},
+);
+const overlayTransition = computed(() =>
+  reduceMotion.value === 'no-preference' ? uiToTransitionProps(ui.value.overlay.transition) : {},
+);
 </script>
 
 <template>
@@ -42,12 +57,21 @@ const { ui } = useUI('dialog', toRef(props, 'ui'), config);
     </Dialog.Trigger>
 
     <Dialog.Portal>
-      <Dialog.Overlay :class="ui.overlay" />
+      <Transition v-bind="overlayTransition">
+        <Dialog.Overlay :class="ui.overlay.base" />
+      </Transition>
 
-      <!-- TODO: Use Transition for animation hooks (after-leave, before-enter, etc) -->
-      <Dialog.Content :class="twMerge(ui.container, ui.size, ui.transition)">
-        <slot name="content" />
-      </Dialog.Content>
+      <Transition
+        v-bind="contentTransition"
+        @before-enter="emits('before-enter')"
+        @after-enter="emits('after-enter')"
+        @before-leave="emits('before-leave')"
+        @after-leave="emits('after-leave')"
+      >
+        <Dialog.Content :class="[ui.container, ui.size]">
+          <slot name="content" />
+        </Dialog.Content>
+      </Transition>
     </Dialog.Portal>
   </Dialog.Root>
 </template>

--- a/src/runtime/components/overlays/Dialog.vue
+++ b/src/runtime/components/overlays/Dialog.vue
@@ -37,15 +37,14 @@ const { ui } = useUI('dialog', toRef(props, 'ui'), config);
 
 <template>
   <Dialog.Root v-model:open="$open">
-    <Dialog.Trigger as-child>
-      <slot name="trigger" :open="$open">
-        <UiButton label="Open" />
-      </slot>
+    <Dialog.Trigger v-if="$slots.trigger" as-child>
+      <slot name="trigger" :open="$open" />
     </Dialog.Trigger>
 
     <Dialog.Portal>
       <Dialog.Overlay :class="ui.overlay" />
 
+      <!-- TODO: Use Transition for animation hooks (after-leave, before-enter, etc) -->
       <Dialog.Content :class="twMerge(ui.container, ui.size, ui.transition)">
         <slot name="content" />
       </Dialog.Content>

--- a/src/runtime/ui.config/dialog.ts
+++ b/src/runtime/ui.config/dialog.ts
@@ -1,8 +1,23 @@
 export default /*ui*/ {
   container: 'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white shadow-xl',
   size: 'w-full max-w-lg',
-  overlay:
-    'fixed inset-0 z-40 bg-black/70 backdrop-blur-sm backdrop-filter duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-  transition:
-    'duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+  overlay: {
+    base: 'fixed inset-0 z-40 bg-black/70 backdrop-blur-sm backdrop-filter',
+    transition: {
+      enterActive: 'ease-out duration-200',
+      enterFrom: 'opacity-0',
+      enterTo: 'opacity-100',
+      leaveActive: 'ease-in duration-200',
+      leaveFrom: 'opacity-100',
+      leaveTo: 'opacity-0',
+    },
+  },
+  transition: {
+    enterActive: 'transition-[opacity,transform] ease-out duration-300',
+    enterFrom: 'opacity-0 -translate-y-[40%] scale-95',
+    enterTo: 'opacity-100 scale-100',
+    leaveActive: 'transition-[opacity,transform] ease-in duration-200',
+    leaveFrom: 'opacity-100 scale-100',
+    leaveTo: 'opacity-0 scale-95',
+  },
 };

--- a/src/runtime/ui.config/slideover.ts
+++ b/src/runtime/ui.config/slideover.ts
@@ -1,8 +1,19 @@
 export default /*ui*/ {
   container: 'fixed z-50 bg-white shadow-xl',
   size: '',
-  overlay:
-    'fixed inset-0 z-40 bg-black/70 backdrop-blur-sm backdrop-filter duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-  transition:
-    'transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  overlay: {
+    base: 'fixed inset-0 z-40 bg-black/70 backdrop-blur-sm backdrop-filter',
+    transition: {
+      enterActive: 'ease-out duration-200',
+      enterFrom: 'opacity-0',
+      enterTo: 'opacity-100',
+      leaveActive: 'ease-in duration-200',
+      leaveFrom: 'opacity-100',
+      leaveTo: 'opacity-0',
+    },
+  },
+  transition: {
+    enterActive: 'transition-transform ease-in-out duration-500',
+    leaveActive: 'transition-transform ease-in-out duration-300',
+  },
 };

--- a/src/runtime/utils/transitions.ts
+++ b/src/runtime/utils/transitions.ts
@@ -1,0 +1,22 @@
+import type { TransitionProps } from 'vue';
+
+export type UiTransition = {
+  enterActive?: string;
+  enterFrom?: string;
+  enterTo?: string;
+  leaveActive?: string;
+  leaveFrom?: string;
+  leaveTo?: string;
+};
+
+/** Converts our simplified transition props into <Transition> props */
+export function uiToTransitionProps(transition: UiTransition): TransitionProps {
+  return {
+    enterActiveClass: transition.enterActive,
+    enterFromClass: transition.enterFrom,
+    enterToClass: transition.enterTo,
+    leaveActiveClass: transition.leaveActive,
+    leaveFromClass: transition.leaveFrom,
+    leaveToClass: transition.leaveTo,
+  };
+}


### PR DESCRIPTION
This PR refactored the `Dialog` and `Slideover` components to allow having no trigger child and give full control to the parent on when to open/close it.

It also implemented the use of the Vue `<Transition>` component for both `<Dialog.Content>` and `<Dialog.Overlay>`, which allows a more detailed control of the animation with css classes and also introduces new events for the animation states:

- `before-enter`
- `after-enter`
- `before-leave`
- `after-leave`

This opens the possibility to perform actions based on the visible state of those overlays but wait for certain transition states.